### PR TITLE
Alterado o limite de caracteres a serem enviados

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ class Zenvia {
       assert(message.to, 'Missing `message.recipient`');
       assert(message.from, 'Missing `message.from`');
       assert(message.msg, 'Missing `message.msg`');
-      assert(message.msg.length <= 140, '`message.msg` needs to be shorter or equal to 140 characters');
+      assert(message.msg.length <= 160, '`message.msg` needs to be shorter or equal to 160 characters');
     } catch (err) {
       return cb(err);
     }


### PR DESCRIPTION
De acordo com a documentação o limite é de 160 caracteres e não 140.

http://docs.zenviasms.apiary.io/#reference/servicos-da-api/envio-de-um-unico-sms