### PR TITLE
changed the zenvia submit URL.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const debug = require('debug')('zenvia');
 const request = require('superagent');
 const uuid = require('uuid');
+const URL_ZENVIA = 'https://api-rest.zenvia.com/services/';
 
 class Zenvia {
   constructor(options = {}) {
@@ -71,7 +72,7 @@ class Zenvia {
 
     debug('Sending SMS request', message.id);
     request
-      .post('https://api-rest.zenvia360.com.br/services/send-sms')
+      .post(`${URL_ZENVIA}/send-sms`)
       .auth(
         options.user || this.user || process.env.ZENVIA_API_USER,
         options.password || this.password || process.env.ZENVIA_API_PASSWORD

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const debug = require('debug')('zenvia');
 const request = require('superagent');
 const uuid = require('uuid');
-const URL_ZENVIA = 'https://api-rest.zenvia.com/services/';
+const URL_ZENVIA = 'https://api-rest.zenvia.com/services';
 
 class Zenvia {
   constructor(options = {}) {


### PR DESCRIPTION
![Enviado por e-mail](http://zenimage.zenvia.com/v/f3jo48ABF0490)

As novas URLs estão disponíveis somente através do protocolo HTTPS e já possuem o certificado atualizado. As antigas serão descontinuadas no dia 18 de agosto de 2018.